### PR TITLE
Update setup.py for publishing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setupOpts = dict(
     name=PLUGIN_NAME,
     description=config['plugin-info']['description'],
     long_description=long_description,
+    long_description_content_type='text/markdown',
     license=config['plugin-info']['license'],
     url=config['plugin-info']['package-url'],
     author=config['plugin-info']['author'],


### PR DESCRIPTION
I faced errors in the deploy workflow of a plugin:

```bash
(pmdaq) C:\Users\XXXXXXXX\Documents\GIT\pymodaq_plugins_piezosystemjena>twine check dist/*
Checking dist\pymodaq_plugins_piezosystemjena-0.1.0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.
         line 2: Warning: Title underline too short.

         PyMoDAQ Piezosystem Jena
         ###############
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
```

I was able to solve this by adding the `long_description_content_type=text/markdown` in setup.py, which apparently is the correct choice for github markdown.

See details in  https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/

Cheers