### PR TITLE
Add twine check to publish action in template

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,4 +34,5 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
+        twine check dist/*
         twine upload dist/*


### PR DESCRIPTION
Didn't add the --strict option of twine check (which stops the process in case of error), since the action will fail anyway at the upload step.

Works great! see my previously buggy rst:
```
Checking dist/pymodaq_plugins_pylablib_camera-1.0.0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 36: Warning: Bullet list ends without a blank line; unexpected    
         unindent.                                                              
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Error: Process completed with exit code 1.
```

note also the WARNING, that is fixed by PR https://github.com/PyMoDAQ/PyMoDAQ/pull/417 on PyMoDAQ

maybe add this to the 5.0.0 branch as well