### PR TITLE
Test and github action to check for compatibility with pymodaq

### DIFF
--- a/.github/workflows/Testbase.yml
+++ b/.github/workflows/Testbase.yml
@@ -41,4 +41,4 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=src/pymodaq/resources/QtDesigner_Ressources,docs
       - name: Test with pytest
         run: |
-          pytest -n auto
+          pytest -n auto -k "not test_compatibility"

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,78 @@
+name: Compatibility with pymodaq (latest release)
+
+on:
+  workflow_call:
+  
+  pull_request:
+
+  push:
+    branches:
+    - '*'
+
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+  
+jobs:
+  tests:
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        qt-backend: ["pyqt5", "pyqt6", "pyside6"]
+    runs-on: ${{ matrix.os }}
+    env:
+      DISPLAY: ':99'
+      QT_DEBUG_PLUGINS: 1
+
+    steps:
+      - name: Set project name environment variable
+        run: |
+          echo "plugin_name=$(echo '${{ github.repository }}' | cut -d'/' -f2)" >> $GITHUB_ENV
+
+      - name: Checkout the repo
+        uses: actions/checkout@v4.2.2
+ 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest pytest-cov pytest-qt pytest-xvfb pytest-xdist setuptools wheel numpy h5py pymodaq ${{ matrix.qt-backend }}
+          pip install -e .    
+      
+      # Create folder and set permissions on Ubuntu
+      - name: Create local pymodaq folder setup env (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-cursor0 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1
+          export QT_DEBUG_PLUGINS=1
+          sudo mkdir -p /etc/.pymodaq
+          sudo chmod uo+rw /etc/.pymodaq
+      - name: Exporting debug variables (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          set QT_DEBUG_PLUGINS=1
+
+      - name: Compatibility tests with ${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.qt-backend}}
+        run: |
+          pytest -vv -n 1 -k "test_compatibility"          
+
+      - name: Upload compatibility report
+        if: failure()
+        uses: actions/upload-artifact@v4.6.1
+        with:
+          name:  
+          path: 'import_report_tests_${{ env.plugin_name }}_None.txt'
+          if-no-files-found: error 
+    
+  

--- a/tests/test_plugin_package_structure.py
+++ b/tests/test_plugin_package_structure.py
@@ -120,7 +120,10 @@ def test_compatibility(capsys):
         pytest.fail(f"Please update pymodaq_plugin_manager to a newer version: {e}")
 
     plugin = PyMoDAQPlugin(get_package_name(), None)
-    res = plugin.all_imports_valid()
+    success = plugin.all_imports_valid()
     msg = '\n'.join(plugin._failed_imports + [''])
 
-    assert res, msg
+    if not success:
+        plugin.save_import_report(".")
+
+    assert success, msg

--- a/tests/test_plugin_package_structure.py
+++ b/tests/test_plugin_package_structure.py
@@ -111,3 +111,16 @@ def test_viewer_has_mandatory_methods(dim):
         klass = getattr(module, f'DAQ_{dim}Viewer_{name}')
         for meth in MANDATORY_VIEWER_METHODS:
             assert hasattr(klass, meth)
+
+def test_compatibility(capsys):
+    capsys.disabled()
+    try:
+        from pymodaq_plugin_manager.compatibility_checker import PyMoDAQPlugin
+    except (ModuleNotFoundError, ImportError) as e:
+        pytest.fail(f"Please update pymodaq_plugin_manager to a newer version: {e}")
+
+    plugin = PyMoDAQPlugin(get_package_name(), None)
+    res = plugin.all_imports_valid()
+    msg = '\n'.join(plugin._failed_imports + [''])
+
+    assert res, msg


### PR DESCRIPTION
A new test that generate a compatibility report is provided for plugin developers. Also included is a github action that generate and upload the compatibility report if needed

To work it needs [pymodaq_plugin_manager/PR#26](https://github.com/PyMoDAQ/pymodaq_plugin_manager/pull/26) to be merged, and a new version of pymodaq_plugin_manager to be released.