### PR TITLE
Features/daqmove improvements

### DIFF
--- a/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
+++ b/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
@@ -93,7 +93,9 @@ class DAQ_Move_Template(DAQ_Move_base):
         """Terminate the communication protocol"""
         ## TODO for your custom plugin
         raise NotImplementedError  # when writing your own plugin remove this line
-        #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
+        if self.is_master:
+            #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
+            ...
 
     def commit_settings(self, param: Parameter):
         """Apply the consequences of a change of value in the detector settings

--- a/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
+++ b/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
@@ -69,7 +69,7 @@ class DAQ_Move_Template(DAQ_Move_base):
         float: The position obtained after scaling conversion.
         """
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         pos = DataActuator(data=self.controller.your_method_to_get_the_actuator_value())  # when writing your own plugin replace this line
         pos = self.get_position_with_scaling(pos)
         return pos
@@ -91,7 +91,7 @@ class DAQ_Move_Template(DAQ_Move_base):
     def close(self):
         """Terminate the communication protocol"""
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
 
     def commit_settings(self, param: Parameter):
@@ -128,7 +128,7 @@ class DAQ_Move_Template(DAQ_Move_base):
         initialized: bool
             False if initialization failed otherwise True
         """
-        raise NotImplemented  # TODO when writing your own plugin remove this line and modify the ones below
+        raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the ones below
         self.ini_stage_init(slave_controller=controller)  # will be useful when controller is slave
 
         if self.is_master:  # is needed when controller is master
@@ -152,7 +152,7 @@ class DAQ_Move_Template(DAQ_Move_base):
         self.target_value = value
         value = self.set_position_with_scaling(value)  # apply scaling if the user specified one
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         self.controller.your_method_to_set_an_absolute_value(value.value())  # when writing your own plugin replace this line
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
 
@@ -168,7 +168,7 @@ class DAQ_Move_Template(DAQ_Move_base):
         value = self.set_position_relative_with_scaling(value)
 
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         self.controller.your_method_to_set_a_relative_value(value.value())  # when writing your own plugin replace this line
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
 
@@ -176,7 +176,7 @@ class DAQ_Move_Template(DAQ_Move_base):
         """Call the reference method of the controller"""
 
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         self.controller.your_method_to_get_to_a_known_reference()  # when writing your own plugin replace this line
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
 
@@ -184,7 +184,7 @@ class DAQ_Move_Template(DAQ_Move_base):
       """Stop the actuator and emits move_done signal"""
 
       ## TODO for your custom plugin
-      raise NotImplemented  # when writing your own plugin remove this line
+      raise NotImplementedError  # when writing your own plugin remove this line
       self.controller.your_method_to_stop_positioning()  # when writing your own plugin replace this line
       self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
 

--- a/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
+++ b/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
@@ -181,12 +181,12 @@ class DAQ_Move_Template(DAQ_Move_base):
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
 
     def stop_motion(self):
-      """Stop the actuator and emits move_done signal"""
+        """Stop the actuator and emits move_done signal"""
 
-      ## TODO for your custom plugin
-      raise NotImplementedError  # when writing your own plugin remove this line
-      self.controller.your_method_to_stop_positioning()  # when writing your own plugin replace this line
-      self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
+        ## TODO for your custom plugin
+        raise NotImplementedError  # when writing your own plugin remove this line
+        self.controller.your_method_to_stop_positioning()  # when writing your own plugin replace this line
+        self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
 
 
 if __name__ == '__main__':

--- a/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
+++ b/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
@@ -130,15 +130,16 @@ class DAQ_Move_Template(DAQ_Move_base):
             False if initialization failed otherwise True
         """
         raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the ones below
-        self.ini_stage_init(slave_controller=controller)  # will be useful when controller is slave
-
         if self.is_master:  # is needed when controller is master
             self.controller = PythonWrapperOfYourInstrument(arg1, arg2, ...) #  arguments for instantiation!)
+            initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # todo
             # todo: enter here whatever is needed for your controller initialization and eventual
             #  opening of the communication channel
+        else:
+            self.controller = controller
+            initialized = True
 
         info = "Whatever info you want to log"
-        initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # todo
         return info, initialized
 
     def move_abs(self, value: DataActuator):

--- a/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
+++ b/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
@@ -70,7 +70,8 @@ class DAQ_Move_Template(DAQ_Move_base):
         """
         ## TODO for your custom plugin
         raise NotImplementedError  # when writing your own plugin remove this line
-        pos = DataActuator(data=self.controller.your_method_to_get_the_actuator_value())  # when writing your own plugin replace this line
+        pos = DataActuator(data=self.controller.your_method_to_get_the_actuator_value(),  # when writing your own plugin replace this line
+                           units=self.axis_unit)
         pos = self.get_position_with_scaling(pos)
         return pos
 
@@ -153,7 +154,7 @@ class DAQ_Move_Template(DAQ_Move_base):
         value = self.set_position_with_scaling(value)  # apply scaling if the user specified one
         ## TODO for your custom plugin
         raise NotImplementedError  # when writing your own plugin remove this line
-        self.controller.your_method_to_set_an_absolute_value(value.value())  # when writing your own plugin replace this line
+        self.controller.your_method_to_set_an_absolute_value(value.value(self.axis_unit))  # when writing your own plugin replace this line
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
 
     def move_rel(self, value: DataActuator):
@@ -169,7 +170,7 @@ class DAQ_Move_Template(DAQ_Move_base):
 
         ## TODO for your custom plugin
         raise NotImplementedError  # when writing your own plugin remove this line
-        self.controller.your_method_to_set_a_relative_value(value.value())  # when writing your own plugin replace this line
+        self.controller.your_method_to_set_a_relative_value(value.value(self.axis_unit))  # when writing your own plugin replace this line
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
 
     def move_home(self):

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
@@ -105,7 +105,9 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
         """Terminate the communication protocol"""
         ## TODO for your custom plugin
         raise NotImplementedError  # when writing your own plugin remove this line
-        #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
+        if self.is_master:
+            #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
+            ...
 
     def grab_data(self, Naverage=1, **kwargs):
         """Start a grab from the detector

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
@@ -83,11 +83,13 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
         """
 
         raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
-        self.ini_detector_init(slave_controller=controller)
-
         if self.is_master:
             self.controller = PythonWrapperOfYourInstrument()  #instantiate you driver with whatever arguments are needed
             self.controller.open_communication() # call eventual methods
+            initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # TODO
+        else:
+            self.controller = controller
+            initialized = True
 
         # TODO for your custom plugin (optional) initialize viewers panel with the future type of data
         self.dte_signal_temp.emit(DataToExport(name='myplugin',
@@ -97,7 +99,6 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
                                                                     labels=['Mock1', 'label2'])]))
 
         info = "Whatever info you want to log"
-        initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # TODO
         return info, initialized
 
     def close(self):

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
@@ -82,7 +82,7 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
             False if initialization failed otherwise True
         """
 
-        raise NotImplemented  # TODO when writing your own plugin remove this line and modify the one below
+        raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
         self.ini_detector_init(slave_controller=controller)
 
         if self.is_master:
@@ -103,7 +103,7 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
     def close(self):
         """Terminate the communication protocol"""
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
 
     def grab_data(self, Naverage=1, **kwargs):
@@ -120,7 +120,7 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
         ## TODO for your custom plugin: you should choose EITHER the synchrone or the asynchrone version following
 
         # synchrone version (blocking function)
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         data_tot = self.controller.your_method_to_start_a_grab_snap()
         self.dte_signal.emit(DataToExport(name='myplugin',
                                           data=[DataFromPlugins(name='Mock1', data=data_tot,
@@ -128,7 +128,7 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
         #########################################################
 
         # asynchrone version (non-blocking function with callback)
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         self.controller.your_method_to_start_a_grab_snap(self.callback)  # when writing your own plugin replace this line
         #########################################################
 
@@ -143,7 +143,7 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
     def stop(self):
         """Stop the current grab hardware wise if necessary"""
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         self.controller.your_method_to_stop_acquisition()  # when writing your own plugin replace this line
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
         ##############################

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
@@ -116,7 +116,9 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
         """Terminate the communication protocol"""
         ## TODO for your custom plugin
         raise NotImplementedError  # when writing your own plugin remove this line
-        #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
+        if self.is_master:
+            #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
+            ...
 
     def grab_data(self, Naverage=1, **kwargs):
         """Start a grab from the detector

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
@@ -87,7 +87,7 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
             False if initialization failed otherwise True
         """
 
-        raise NotImplemented  # TODO when writing your own plugin remove this line and modify the one below
+        raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
         self.ini_detector_init(slave_controller=controller)
 
         if self.is_master:
@@ -114,7 +114,7 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
     def close(self):
         """Terminate the communication protocol"""
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
 
     def grab_data(self, Naverage=1, **kwargs):
@@ -152,7 +152,7 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
     def stop(self):
         """Stop the current grab hardware wise if necessary"""
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         self.controller.your_method_to_stop_acquisition()  # when writing your own plugin replace this line
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
         ##############################

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
@@ -88,11 +88,13 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
         """
 
         raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
-        self.ini_detector_init(slave_controller=controller)
-
         if self.is_master:
             self.controller = PythonWrapperOfYourInstrument()  #instantiate you driver with whatever arguments are needed
             self.controller.open_communication() # call eventual methods
+            initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # TODO
+        else:
+            self.controller = controller
+            initialized = True
 
         ## TODO for your custom plugin
         # get the x_axis (you may want to to this also in the commit settings if x_axis may have changed
@@ -108,7 +110,6 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
                                                                      axes=[self.x_axis])]))
 
         info = "Whatever info you want to log"
-        initialized = True
         return info, initialized
 
     def close(self):

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
@@ -113,7 +113,9 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
         """Terminate the communication protocol"""
         ## TODO for your custom plugin
         raise NotImplementedError  # when writing your own plugin remove this line
-        #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
+        if self.is_master:
+            #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
+            ...
 
     def grab_data(self, Naverage=1, **kwargs):
         """Start a grab from the detector

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
@@ -83,11 +83,13 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
             False if initialization failed otherwise True
         """
         raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
-        self.ini_detector_init(slave_controller=controller)
-
         if self.is_master:
             self.controller = PythonWrapperOfYourInstrument()  #instantiate you driver with whatever arguments are needed
             self.controller.open_communication() # call eventual methods
+            initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # TODO
+        else:
+            self.controller = controller
+            initialized = True
 
         ## TODO for your custom plugin
         # get the x_axis (you may want to to this also in the commit settings if x_axis may have changed
@@ -105,7 +107,6 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
                                                                      axes=[self.x_axis, self.y_axis]), ]))
 
         info = "Whatever info you want to log"
-        initialized = True
         return info, initialized
 
     def close(self):

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
@@ -82,7 +82,7 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
         initialized: bool
             False if initialization failed otherwise True
         """
-        raise NotImplemented  # TODO when writing your own plugin remove this line and modify the one below
+        raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
         self.ini_detector_init(slave_controller=controller)
 
         if self.is_master:
@@ -111,7 +111,7 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
     def close(self):
         """Terminate the communication protocol"""
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         #  self.controller.your_method_to_terminate_the_communication()  # when writing your own plugin replace this line
 
     def grab_data(self, Naverage=1, **kwargs):
@@ -150,7 +150,7 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
     def stop(self):
         """Stop the current grab hardware wise if necessary"""
         ## TODO for your custom plugin
-        raise NotImplemented  # when writing your own plugin remove this line
+        raise NotImplementedError  # when writing your own plugin remove this line
         self.controller.your_method_to_stop_acquisition()  # when writing your own plugin replace this line
         self.emit_status(ThreadCommand('Update_Status', ['Some info you want to log']))
         ##############################


### PR DESCRIPTION
4 small improvements:

- Corrected `NotImplemented` to `NotImplementedError` for all instances in `daq_move` and `daq_viewer` files.
- Corrected indent of `.stop_motion()` code in `daq_move` to set it the same as other methods in the class.
- Added calls to `.axis_unit` to explicitly set the `DataActuator` unit used (for getting current value and for conversion before sending to controller methods) to the one configured in the class parameters.
- Switched to new implementation of master/slave declaration in `.close()`, `.ini_stage()` (`daq_move`) and `.ini_detector()` (`daq_viewerxD`)