### PR TITLE
Replace first TODO instruction to import the wrapper of the instrument

### DIFF
--- a/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
+++ b/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
@@ -6,10 +6,8 @@ from pymodaq.control_modules.move_utility_classes import (DAQ_Move_base, comon_p
 from pymodaq_utils.utils import ThreadCommand  # object used to send info back to the main thread
 from pymodaq_gui.parameter import Parameter
 
-
-class PythonWrapperOfYourInstrument:
-    #  TODO Replace this fake class with the import of the real python wrapper of your instrument
-    pass
+#  TODO Replace this fake import with the import of the real python wrapper of your instrument
+from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import PythonWrapperObjectOfYourInstrument
 
 # TODO:
 # (1) change the name of the following class to DAQ_Move_TheNameOfYourChoice
@@ -56,7 +54,7 @@ class DAQ_Move_Template(DAQ_Move_base):
     def ini_attributes(self):
         #  TODO declare the type of the wrapper (and assign it to self.controller) you're going to use for easy
         #  autocompletion
-        self.controller: PythonWrapperOfYourInstrument = None
+        self.controller: PythonWrapperObjectOfYourInstrument = None
 
         #TODO declare here attributes you want/need to init with a default value
         pass
@@ -133,7 +131,7 @@ class DAQ_Move_Template(DAQ_Move_base):
         """
         raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the ones below
         if self.is_master:  # is needed when controller is master
-            self.controller = PythonWrapperOfYourInstrument(arg1, arg2, ...) #  arguments for instantiation!)
+            self.controller = PythonWrapperObjectOfYourInstrument(arg1, arg2, ...) #  arguments for instantiation!)
             initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # todo
             # todo: enter here whatever is needed for your controller initialization and eventual
             #  opening of the communication channel

--- a/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
+++ b/src/pymodaq_plugins_template/daq_move_plugins/daq_move_Template.py
@@ -6,8 +6,10 @@ from pymodaq.control_modules.move_utility_classes import (DAQ_Move_base, comon_p
 from pymodaq_utils.utils import ThreadCommand  # object used to send info back to the main thread
 from pymodaq_gui.parameter import Parameter
 
-#  TODO Replace this fake import with the import of the real python wrapper of your instrument
-from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import PythonWrapperObjectOfYourInstrument
+#  TODO:
+#  Replace the following fake import with the import of the real Python wrapper of your instrument. Here we suppose that
+#  the wrapper is in the hardware directory, but it could come from an external librairy like pylablib or pymeasure.
+from pymodaq_plugins_template.hardware.python_wrapper_file_of_your_instrument import PythonWrapperObjectOfYourInstrument
 
 # TODO:
 # (1) change the name of the following class to DAQ_Move_TheNameOfYourChoice
@@ -15,6 +17,8 @@ from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import 
 #     for the class name and the file name.)
 # (3) this file should then be put into the right folder, namely IN THE FOLDER OF THE PLUGIN YOU ARE DEVELOPING:
 #     pymodaq_plugins_my_plugin/daq_move_plugins
+
+
 class DAQ_Move_Template(DAQ_Move_base):
     """ Instrument plugin class for an actuator.
     

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
@@ -7,9 +7,8 @@ from pymodaq_gui.parameter import Parameter
 from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, comon_parameters, main
 from pymodaq.utils.data import DataFromPlugins
 
-class PythonWrapperOfYourInstrument:
-    #  TODO Replace this fake class with the import of the real python wrapper of your instrument
-    pass
+#  TODO Replace this fake import with the import of the real python wrapper of your instrument
+from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import PythonWrapperObjectOfYourInstrument
 
 # TODO:
 # (1) change the name of the following class to DAQ_0DViewer_TheNameOfYourChoice
@@ -47,7 +46,7 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
     def ini_attributes(self):
         #  TODO declare the type of the wrapper (and assign it to self.controller) you're going to use for easy
         #  autocompletion
-        self.controller: PythonWrapperOfYourInstrument = None
+        self.controller: PythonWrapperObjectOfYourInstrument = None
 
         #TODO declare here attributes you want/need to init with a default value
         pass
@@ -84,7 +83,7 @@ class DAQ_0DViewer_Template(DAQ_Viewer_base):
 
         raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
         if self.is_master:
-            self.controller = PythonWrapperOfYourInstrument()  #instantiate you driver with whatever arguments are needed
+            self.controller = PythonWrapperObjectOfYourInstrument()  #instantiate you driver with whatever arguments are needed
             self.controller.open_communication() # call eventual methods
             initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # TODO
         else:

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_0D/daq_0Dviewer_Template.py
@@ -7,8 +7,10 @@ from pymodaq_gui.parameter import Parameter
 from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, comon_parameters, main
 from pymodaq.utils.data import DataFromPlugins
 
-#  TODO Replace this fake import with the import of the real python wrapper of your instrument
-from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import PythonWrapperObjectOfYourInstrument
+#  TODO:
+#  Replace the following fake import with the import of the real Python wrapper of your instrument. Here we suppose that
+#  the wrapper is in the hardware directory, but it could come from an external librairy like pylablib or pymeasure.
+from pymodaq_plugins_template.hardware.python_wrapper_file_of_your_instrument import PythonWrapperObjectOfYourInstrument
 
 # TODO:
 # (1) change the name of the following class to DAQ_0DViewer_TheNameOfYourChoice
@@ -16,6 +18,7 @@ from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import 
 #     for the class name and the file name.)
 # (3) this file should then be put into the right folder, namely IN THE FOLDER OF THE PLUGIN YOU ARE DEVELOPING:
 #     pymodaq_plugins_my_plugin/daq_viewer_plugins/plugins_0D
+
 
 class DAQ_0DViewer_Template(DAQ_Viewer_base):
     """ Instrument plugin class for a OD viewer.

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
@@ -7,10 +7,8 @@ from pymodaq_gui.parameter import Parameter
 from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, comon_parameters, main
 from pymodaq.utils.data import DataFromPlugins
 
-
-class PythonWrapperOfYourInstrument:
-    #  TODO Replace this fake class with the import of the real python wrapper of your instrument
-    pass
+#  TODO Replace this fake import with the import of the real python wrapper of your instrument
+from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import PythonWrapperObjectOfYourInstrument
 
 # TODO:
 # (1) change the name of the following class to DAQ_1DViewer_TheNameOfYourChoice
@@ -51,7 +49,7 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
     def ini_attributes(self):
         #  TODO declare the type of the wrapper (and assign it to self.controller) you're going to use for easy
         #  autocompletion
-        self.controller: PythonWrapperOfYourInstrument = None
+        self.controller: PythonWrapperObjectOfYourInstrument = None
 
         # TODO declare here attributes you want/need to init with a default value
 
@@ -89,7 +87,7 @@ class DAQ_1DViewer_Template(DAQ_Viewer_base):
 
         raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
         if self.is_master:
-            self.controller = PythonWrapperOfYourInstrument()  #instantiate you driver with whatever arguments are needed
+            self.controller = PythonWrapperObjectOfYourInstrument()  #instantiate you driver with whatever arguments are needed
             self.controller.open_communication() # call eventual methods
             initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # TODO
         else:

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Template.py
@@ -7,8 +7,10 @@ from pymodaq_gui.parameter import Parameter
 from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, comon_parameters, main
 from pymodaq.utils.data import DataFromPlugins
 
-#  TODO Replace this fake import with the import of the real python wrapper of your instrument
-from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import PythonWrapperObjectOfYourInstrument
+#  TODO:
+#  Replace the following fake import with the import of the real Python wrapper of your instrument. Here we suppose that
+#  the wrapper is in the hardware directory, but it could come from an external librairy like pylablib or pymeasure.
+from pymodaq_plugins_template.hardware.python_wrapper_file_of_your_instrument import PythonWrapperObjectOfYourInstrument
 
 # TODO:
 # (1) change the name of the following class to DAQ_1DViewer_TheNameOfYourChoice

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
@@ -6,9 +6,9 @@ from pymodaq_gui.parameter import Parameter
 
 from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, comon_parameters, main
 from pymodaq.utils.data import DataFromPlugins
-class PythonWrapperOfYourInstrument:
-    #  TODO Replace this fake class with the import of the real python wrapper of your instrument
-    pass
+
+#  TODO Replace this fake import with the import of the real python wrapper of your instrument
+from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import PythonWrapperObjectOfYourInstrument
 
 # TODO:
 # (1) change the name of the following class to DAQ_2DViewer_TheNameOfYourChoice
@@ -47,7 +47,7 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
     def ini_attributes(self):
         #  TODO declare the type of the wrapper (and assign it to self.controller) you're going to use for easy
         #  autocompletion
-        self.controller: PythonWrapperOfYourInstrument = None
+        self.controller: PythonWrapperObjectOfYourInstrument = None
 
         # TODO declare here attributes you want/need to init with a default value
 
@@ -84,7 +84,7 @@ class DAQ_2DViewer_Template(DAQ_Viewer_base):
         """
         raise NotImplementedError  # TODO when writing your own plugin remove this line and modify the one below
         if self.is_master:
-            self.controller = PythonWrapperOfYourInstrument()  #instantiate you driver with whatever arguments are needed
+            self.controller = PythonWrapperObjectOfYourInstrument()  #instantiate you driver with whatever arguments are needed
             self.controller.open_communication() # call eventual methods
             initialized = self.controller.a_method_or_atttribute_to_check_if_init()  # TODO
         else:

--- a/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
+++ b/src/pymodaq_plugins_template/daq_viewer_plugins/plugins_2D/daq_2Dviewer_Template.py
@@ -7,8 +7,10 @@ from pymodaq_gui.parameter import Parameter
 from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, comon_parameters, main
 from pymodaq.utils.data import DataFromPlugins
 
-#  TODO Replace this fake import with the import of the real python wrapper of your instrument
-from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import PythonWrapperObjectOfYourInstrument
+#  TODO:
+#  Replace the following fake import with the import of the real Python wrapper of your instrument. Here we suppose that
+#  the wrapper is in the hardware directory, but it could come from an external librairy like pylablib or pymeasure.
+from pymodaq_plugins_template.hardware.python_wrapper_file_of_your_instrument import PythonWrapperObjectOfYourInstrument
 
 # TODO:
 # (1) change the name of the following class to DAQ_2DViewer_TheNameOfYourChoice
@@ -16,6 +18,8 @@ from pymodaq_plugins_template.hardware.PythonWrapperFileOfYourInstrument import 
 #     for the class name and the file name.)
 # (3) this file should then be put into the right folder, namely IN THE FOLDER OF THE PLUGIN YOU ARE DEVELOPING:
 #     pymodaq_plugins_my_plugin/daq_viewer_plugins/plugins_2D
+
+
 class DAQ_2DViewer_Template(DAQ_Viewer_base):
     """ Instrument plugin class for a 2D viewer.
     


### PR DESCRIPTION
Modification of the first TODO instruction that was a bit misleading for the newcomer, and could lead him to copy-paste the content of his instrument wrapper in the plugin.
The good practise is rather to lead him to import the wrapper object.